### PR TITLE
Added bias on comm distance estimation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.vscode/

--- a/src/plugins/robots/kilobot/simulator/kilobot_communication_default_sensor.cpp
+++ b/src/plugins/robots/kilobot/simulator/kilobot_communication_default_sensor.cpp
@@ -19,6 +19,9 @@ namespace argos {
       m_fDistanceNoiseStdDev(0.0f),
       m_pcRNG(NULL),
       m_cSpace(CSimulator::GetInstance().GetSpace()),
+      m_fDistanceBias(1.0f),
+      m_fDistanceBiasMean(1.0f),
+      m_fDistanceBiasStdDev(0.0f),
       m_bShowRays(false) {}
 
    /****************************************/
@@ -53,6 +56,20 @@ namespace argos {
          /* Enable the Kilobot communication entity */
          m_pcCommEntity->SetMedium(*m_pcMedium);
          m_pcCommEntity->Enable();
+
+         GetNodeAttributeOrDefault(t_tree, "noise_std_dev", m_fDistanceNoiseStdDev, m_fDistanceNoiseStdDev);
+         GetNodeAttributeOrDefault(t_tree, "distance_bias_mean", m_fDistanceBiasMean, m_fDistanceBiasMean);
+         GetNodeAttributeOrDefault(t_tree, "distance_bias_std_dev", m_fDistanceBiasStdDev, m_fDistanceBiasStdDev);
+
+         if (m_fDistanceNoiseStdDev > 0.0f || m_fDistanceBiasStdDev > 0.0f)
+         {
+            m_pcRNG = CRandom::CreateRNG("argos");
+         }
+
+         if (m_fDistanceBiasStdDev > 0.0f)
+         {
+            m_fDistanceBias = m_pcRNG->Gaussian(m_fDistanceBiasStdDev, m_fDistanceBiasMean);
+         }
       }
       catch(CARGoSException& ex) {
          THROW_ARGOSEXCEPTION_NESTED("Error initializing the Kilobot communication medium sensor", ex);
@@ -103,89 +120,101 @@ namespace argos {
             m_pcControllableEntity->AddCheckedRay(false,
                                                   CRay3(cOtherCommEntity.GetPosition(),
                                                         m_pcCommEntity->GetPosition()));
-         }
-         /* Set message data */
-         sPacket.Message = cOtherCommEntity.GetTxMessage();
-         /* Set message distance */
-         sPacket.Distance.low_gain = 0;
-         sPacket.Distance.high_gain = Distance(m_pcCommEntity->GetPosition(),
-                                               cOtherCommEntity.GetPosition()) * 1000.0;
-         if(m_pcRNG)
+        }
+        /* Set message data */
+        sPacket.Message = cOtherCommEntity.GetTxMessage();
+        /* Set message distance */
+        sPacket.Distance.low_gain = 0;
+        sPacket.Distance.high_gain = Distance(m_pcCommEntity->GetPosition(),
+                                              cOtherCommEntity.GetPosition()) *
+                                     1000.0;
+
+        sPacket.Distance.high_gain = int(float(sPacket.Distance.high_gain) / m_fDistanceBias);
+
+        if (m_pcRNG && m_fDistanceNoiseStdDev > 0.0f)
             sPacket.Distance.high_gain += m_pcRNG->Gaussian(m_fDistanceNoiseStdDev);
-         /* Add message to the list */
-         m_tPackets.push_back(sPacket);
-      } /* communicating neighbors loop */
-   }
-   
-   /****************************************/
-   /****************************************/
+        int16_t zero = 0U;
+        int16_t max = 255U;
+        CRange<int16_t> range = CRange<int16_t>(zero, max);
+        // const int16_t high_gain = sPacket.Distance.high_gain;
+        range.TruncValue((&sPacket.Distance)->high_gain);
 
-   void CKilobotCommunicationDefaultSensor::Reset() {
-      m_tPackets.clear();
-      m_bMessageSent = false;
-   }
-
-   /****************************************/
-   /****************************************/
-
-   void CKilobotCommunicationDefaultSensor::Destroy() {
-      m_pcCommEntity->Disable();
-   }
-
-   /****************************************/
-   /****************************************/
-
-   REGISTER_SENSOR(CKilobotCommunicationDefaultSensor,
-                   "kilobot_communication", "default",
-                   "Carlo Pinciroli [ilpincy@gmail.com]",
-                   "1.0",
-                   "The Kilobot communication sensor.",
-                   "This sensor allows Kilobots to perform situated communication, i.e., a form of\n"
-                   "wireless communication whereby the receiver also knows the distance of the\n"
-                   "sender. This sensor is associated to the Kilobot communication medium. To be\n"
-                   "able to use this sensor, you must add a Kilobot communication medium to the\n"
-                   "<media> section. To use this sensor, in controllers you must include the\n"
-                   "ci_kilobot_communication_sensor.h header. This sensor only allows a Kilobot to\n"
-                   "receive messages. To send messages, you need the Kilobot communication actuator.\n\n"
-                   "REQUIRED XML CONFIGURATION\n\n"
-                   "  <controllers>\n"
-                   "    ...\n"
-                   "    <my_controller ...>\n"
-                   "      ...\n"
-                   "      <sensors>\n"
-                   "        ...\n"
-                   "        <kilobot_communication implementation=\"default\"\n"
-                   "                               medium=\"kilomedium\" />\n"
-                   "        ...\n"
-                   "      </sensors>\n"
-                   "      ...\n"
-                   "    </my_controller>\n"
-                   "    ...\n"
-                   "  </controllers>\n\n"
-                   "The 'medium' attribute must be set to the id of the Kilobot communication\n"
-                   "medium declared in the <media> section.\n\n"
-                   "OPTIONAL XML CONFIGURATION\n\n"
-                   "It is possible to draw the rays shot by the Kilobot communication sensor in the\n"
-                   "OpenGL visualization. This can be useful for sensor debugging but also to\n"
-                   "understand what's wrong in your controller. In OpenGL, the rays are drawn in\n"
-                   "cyan when two robots are communicating.\n"
-                   "To turn this functionality on, add the attribute \"show_rays\" as in this\n"
-                   "example:\n\n"
-                   "  <controllers>\n"
-                   "    ...\n"
-                   "    <my_controller ...>\n"
-                   "      ...\n"
-                   "      <sensors>\n"
-                   "        ...\n"
-                   "        <kilobot_communication implementation=\"default\"\n"
-                   "                               medium=\"kilomedium\"\n"
-                   "                               show_rays=\"true\" />\n"
-                   "        ...\n"
-                   "      </sensors>\n"
-                   "      ...\n"
-                   "    </my_controller>\n"
-                   "    ...\n"
-                   "  </controllers>\n",
-                   "Usable");
-   
+        /* Add message to the list */
+        m_tPackets.push_back(sPacket);
+    } /* communicating neighbors loop */
 }
+
+/****************************************/
+/****************************************/
+
+void CKilobotCommunicationDefaultSensor::Reset()
+{
+    m_tPackets.clear();
+    m_bMessageSent = false;
+}
+
+/****************************************/
+/****************************************/
+
+void CKilobotCommunicationDefaultSensor::Destroy()
+{
+    m_pcCommEntity->Disable();
+}
+
+/****************************************/
+/****************************************/
+
+REGISTER_SENSOR(CKilobotCommunicationDefaultSensor,
+                "kilobot_communication", "default",
+                "Carlo Pinciroli [ilpincy@gmail.com]",
+                "1.0",
+                "The Kilobot communication sensor.",
+                "This sensor allows Kilobots to perform situated communication, i.e., a form of\n"
+                "wireless communication whereby the receiver also knows the distance of the\n"
+                "sender. This sensor is associated to the Kilobot communication medium. To be\n"
+                "able to use this sensor, you must add a Kilobot communication medium to the\n"
+                "<media> section. To use this sensor, in controllers you must include the\n"
+                "ci_kilobot_communication_sensor.h header. This sensor only allows a Kilobot to\n"
+                "receive messages. To send messages, you need the Kilobot communication actuator.\n\n"
+                "REQUIRED XML CONFIGURATION\n\n"
+                "  <controllers>\n"
+                "    ...\n"
+                "    <my_controller ...>\n"
+                "      ...\n"
+                "      <sensors>\n"
+                "        ...\n"
+                "        <kilobot_communication implementation=\"default\"\n"
+                "                               medium=\"kilomedium\" />\n"
+                "        ...\n"
+                "      </sensors>\n"
+                "      ...\n"
+                "    </my_controller>\n"
+                "    ...\n"
+                "  </controllers>\n\n"
+                "The 'medium' attribute must be set to the id of the Kilobot communication\n"
+                "medium declared in the <media> section.\n\n"
+                "OPTIONAL XML CONFIGURATION\n\n"
+                "It is possible to draw the rays shot by the Kilobot communication sensor in the\n"
+                "OpenGL visualization. This can be useful for sensor debugging but also to\n"
+                "understand what's wrong in your controller. In OpenGL, the rays are drawn in\n"
+                "cyan when two robots are communicating.\n"
+                "To turn this functionality on, add the attribute \"show_rays\" as in this\n"
+                "example:\n\n"
+                "  <controllers>\n"
+                "    ...\n"
+                "    <my_controller ...>\n"
+                "      ...\n"
+                "      <sensors>\n"
+                "        ...\n"
+                "        <kilobot_communication implementation=\"default\"\n"
+                "                               medium=\"kilomedium\"\n"
+                "                               show_rays=\"true\" />\n"
+                "        ...\n"
+                "      </sensors>\n"
+                "      ...\n"
+                "    </my_controller>\n"
+                "    ...\n"
+                "  </controllers>\n",
+                "Usable");
+
+} // namespace argos

--- a/src/plugins/robots/kilobot/simulator/kilobot_communication_default_sensor.h
+++ b/src/plugins/robots/kilobot/simulator/kilobot_communication_default_sensor.h
@@ -49,6 +49,9 @@ namespace argos {
       Real                         m_fDistanceNoiseStdDev;
       CRandom::CRNG*               m_pcRNG;
       CSpace&                      m_cSpace;
+      Real m_fDistanceBias;
+      Real m_fDistanceBiasMean;
+      Real m_fDistanceBiasStdDev;
       bool                         m_bShowRays;
    };
 


### PR DESCRIPTION
I added a multiplication factor (bias) on the estimation of received distance, to account for the fact that actually Kilobot have a very noisy internal estimation. 

At init(), a bias is chosen on a Gaussian (sigma and mu are given in configuration files). 
Then it is apply in update(), plus the already existing white noise.

This is because we had in reality communication up to 20 cm away (not 10...).

Because of my code editor that formats automatically my code, the rest of the files are modified a bit too, but there should not be any change in them.